### PR TITLE
Now not using global $driver var anywhere

### DIFF
--- a/features/step_definitions/screen_factory.rb
+++ b/features/step_definitions/screen_factory.rb
@@ -1,9 +1,10 @@
 class ScreenFactory
 
-  def initialize platform
+  def initialize platform, driver
     @platform = platform
+    @driver = driver
   end
-  
+
   def get_commit_list_screen
     get_screen_by_key "CommitListScreen"
   end
@@ -15,9 +16,9 @@ class ScreenFactory
   def get_screen_by_key screen_name
     case @platform
     when 'android'
-      Object::const_get("Android#{screen_name}").new()
+      Object::const_get("Android#{screen_name}").new(@driver)
     when 'ios'
-      Object::const_get("Ios#{screen_name}").new()
+      Object::const_get("Ios#{screen_name}").new(@driver)
     else
       raise "Unexpected platform '#{@platform}', cannot get get screen by screen_name '#{screen_name}'"
     end

--- a/features/step_definitions/screens/android_commit_list_screen.rb
+++ b/features/step_definitions/screens/android_commit_list_screen.rb
@@ -1,22 +1,22 @@
 require_relative 'commit_list_screen'
 
 class AndroidCommitListScreen < CommitListScreen
-	
+
 	def get_title
 		# Get the ActionBar text - assume its the first TextView in the view hierarchy
-		$driver.find_element(class: 'android.widget.TextView').name
+		@driver.find_element(class: 'android.widget.TextView').name
 	end
 
 	def has_commit_message message
-		listview = $driver.find_element(id: ids[:commitlist_list])
+		listview = element(ids[:commitlist_list])
 
-		$driver.execute_script("mobile: scrollTo", :element => listview.ref, :text => message)
+		@driver.execute_script("mobile: scrollTo", :element => listview.ref, :text => message)
 	end
 
 	def has_date date
-		listview = $driver.find_element(id: ids[:commitlist_list])
+		listview = element(ids[:commitlist_list])
 
-		$driver.execute_script("mobile: scrollTo", :element => listview.ref, :text => date)
+		@driver.execute_script("mobile: scrollTo", :element => listview.ref, :text => date)
 	end
 
 	def ids
@@ -36,5 +36,5 @@ class AndroidCommitListScreen < CommitListScreen
 
     	map
   end
-	
+
 end

--- a/features/step_definitions/screens/base_screen.rb
+++ b/features/step_definitions/screens/base_screen.rb
@@ -1,16 +1,62 @@
 class BaseScreen
 
-	def ids
-		raise "SubclassResponsibility - your AndroidScreen/IosScreen should override this method!" 
-	end
-
-	def is_on_screen id
-		$driver.find_element(id: id).displayed?
+	def initialize driver
+		@driver = driver
 	end
 
 	def wait_for_load
 		# NOTE (JD): get rid of the sleep
 		# and monitor the state of the loaders
 		sleep 2
+	end
+
+	def ids
+		raise "SubclassResponsibility - your AndroidScreen/IosScreen should override this method!"
+	end
+
+	private
+	def element id
+		@driver.find_element(id: id)
+	end
+
+	def elements id
+		@driver.find_elements(id: id)
+	end
+
+	def element_by_text text
+		@driver.find_element(name: text)
+	end
+
+	def elements_by_text text
+		@driver.find_elements(name: text)
+	end
+
+	def has_element id
+		begin
+			e = element(id)
+			!e.nil? && e.displayed?
+		rescue
+			false
+		end
+	end
+
+	def has_no_element id
+
+		@driver.set_wait(0)
+
+		has = nil
+
+		500.times do
+			has = has_element(id)
+			break if !has
+			sleep 0.2
+		end
+
+		@driver.set_wait(30)
+		!has
+	end
+
+	def get_text id
+		element(id).text
 	end
 end

--- a/features/step_definitions/screens/commit_detail_screen.rb
+++ b/features/step_definitions/screens/commit_detail_screen.rb
@@ -3,7 +3,7 @@ require_relative 'base_screen'
 class CommitDetailScreen < BaseScreen
 
 	def is_on_commit_detail_screen
-		is_on_screen ids[:commit_detail_root]
+		has_element(ids[:commit_detail_root])
 	end
 
 end

--- a/features/step_definitions/screens/commit_list_screen.rb
+++ b/features/step_definitions/screens/commit_list_screen.rb
@@ -2,36 +2,32 @@ require_relative 'base_screen'
 
 class CommitListScreen < BaseScreen
 
-	def get_text id
-		$driver.find_element(id: ids[id]).text
-	end
-
 	def wait_for_load
 		has_no_loading_indicator
 	end
 
 	def get_title
-		get_text(:commitlist_title)
+		get_text(ids[:commitlist_title])
 	end
 
 	def has_error_indicator
-		$driver.find_element(id: ids[:commitlist_no_commits_indicator]).displayed?
+		has_element(ids[:commitlist_no_commits_indicator])
 	end
 
 	def click_on_commit index
-		$driver.find_elements(id: ids[:commitlist_row])[index].click
+		elements(ids[:commitlist_row])[index].click
 	end
-	
+
 	def has_commit_message text
-		!$driver.find_element(name: text).nil?
+		!element_by_text(text).nil?
 	end
 
 	def has_date text
-		!$driver.find_element(name: text).nil?
+		!element_by_text(text).nil?
 	end
 
 	def has_no_commits_indicator
-		$driver.find_element(id: ids[:commitlist_no_commits_indicator]).displayed?
+		has_element(ids[:commitlist_no_commits_indicator])
 	end
 
 	def has_loading_indicator
@@ -43,48 +39,18 @@ class CommitListScreen < BaseScreen
 	end
 
 	def get_number_of_commits
-		$driver.find_elements(name: ids[:commit_list_list_row]).count
+		elements_by_text(ids[:commit_list_list_row]).count
 	end
 
 	def get_commit_list
-		$driver.find_element(id: ids[:commitlist_list])
-	end
-
-	def get_commits_error_indicator
-		$driver.find_element(id: ids[:commitlist_no_commits_indicator])
+		element(ids[:commitlist_list])
 	end
 
 	def has_commits_error_indicator
-		get_commits_error_indicator.displayed?
+		has_element(ids[:commitlist_no_commits_indicator])
 	end
 
 	def get_commits_error
-		get_commits_error_indicator.text
-	end
-
-	private
-	def has_element id
-		begin
-			element = $driver.find_element(id: id)
-			!element.nil? && element.displayed?
-		rescue
-			false
-		end
-	end
-
-	def has_no_element id
-
-		$driver.set_wait(0)
-
-		has = nil
-
-		500.times do
-			has = has_element(id)
-			break if !has
-			sleep 0.2
-		end
-
-		$driver.set_wait(30)
-		!has
+		get_text(ids[:commitlist_no_commits_indicator])
 	end
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -32,5 +32,5 @@ end
 
 at_exit do
   GitHubMockBackend::Boot.exit
-  $driver.driver_quit
+  CustomWorld.exit
 end


### PR DESCRIPTION
Also cleaned up methods in BaseScreen and POs. Moved a bunch of common methods / shortcuts to BaseScreen so the specific POs only implement things specific to that screen.
