### PR TITLE
Fix failing scenario on iOS

### DIFF
--- a/features/step_definitions/commit_list_steps.rb
+++ b/features/step_definitions/commit_list_steps.rb
@@ -109,6 +109,8 @@ Given(/^the json retrieved from the server is broken$/) do
 end
 
 Then(/^I should see an indicator of server error$/) do
+  sleep 61
+  
   expect(@screen.has_commits_error_indicator).to be(true), "Expected commit error indicator is displayed"
 end
 


### PR DESCRIPTION
Scenario `client-side time out` on iOS was failing because there was no sleep - app wasn't given a sufficient length of time to actually timeout. Was passing on android, but probably shouldn't have been.

Now passing on both.
