### PR TITLE
Fixed the display loading indicator test for Android

### DIFF
--- a/features/step_definitions/screens/base_screen.rb
+++ b/features/step_definitions/screens/base_screen.rb
@@ -58,12 +58,13 @@ class BaseScreen
 		element_id = ''
 		case @platform
 		when 'android'
-			# We need the package name at the start of the id for android unless what we're 
-			# testing has already been fully qualified, e.g. if it's part of the system UI
+			# We need the package name at the start of the id for android unless what we're
+			# testing has already been fully qualified, e.g. if it's part of the system UI.
+			# Read more about it in docs/finding_elements.md
 			element = ids[id]
-			element_id = element[:id] 
-			if !ids.has_key?('is_fully_qualified') || !element[:is_fully_qualified]
-				element_id = ANDROID_PACKAGE_ELEMENT_ID_PREFIX + element[:id] 
+			element_id = element[:id]
+			if !element.has_key?(:is_fully_qualified) || !element[:is_fully_qualified]
+				element_id = ANDROID_PACKAGE_ELEMENT_ID_PREFIX + element[:id]
 			end
 		when 'ios'
 			element_id = ids[id]

--- a/features/step_definitions/screens/commit_list_screen.rb
+++ b/features/step_definitions/screens/commit_list_screen.rb
@@ -31,6 +31,10 @@ class CommitListScreen < BaseScreen
 	end
 
 	# Loading
+	def wait_for_load
+		has_no_element(get_id(:commitlist_loading_indicator))
+	end
+
 	def has_no_commits_indicator
 		has_element(get_id(:commitlist_no_commits_indicator))
 	end


### PR DESCRIPTION
Have a look @emmaguy, there was a silly bug when working out the element ID, but also the implementation to work out when the page had loaded was a bit flaky.

Now seems robust, consistently passing on both platforms.

J
