### PR TITLE
Remove ugly and unnecessary sleep at the step def.

### DIFF
--- a/features/step_definitions/commit_list_steps.rb
+++ b/features/step_definitions/commit_list_steps.rb
@@ -103,7 +103,6 @@ Given(/^the json retrieved from the server is broken$/) do
 end
 
 Then(/^I should see an indicator of server error$/) do
-  sleep SERVER_TIME_OUT_DELAY
   expect(@screen.has_commits_error_indicator).to be(true), "Expected commit error indicator is displayed"
 end
 


### PR DESCRIPTION
Unsure how it ended up in there, but it's gone and tests consistently pass both for iOS and Android.
